### PR TITLE
Configure make files for python3 support only

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = python3 -msphinx
 SPHINXPROJ    = asciju
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,8 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
+html_static_path = []
 
 
 # -- Options for HTMLHelp output ---------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,6 @@ Welcome to asciju's documentation!
    readme
    installation
    usage
-   modules
    contributing
    authors
    history

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -5,7 +5,7 @@ pushd %~dp0
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=python -msphinx
+	set SPHINXBUILD=python3 -msphinx
 )
 set SOURCEDIR=.
 set BUILDDIR=_build

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,5 +7,5 @@ tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
-PIL==7.2.0
 tox-travis==0.12
+Pillow


### PR DESCRIPTION
- fix python3 support only in Makefile and Make.bat
- Fix two warnings during make html execution