### PR TITLE
 fixed: the image is not loaded in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Run the python script::
         python3 nameofthescript.py
 
 
-.. image:: assets/run.gif
+.. image:: ./assets/run.gif
 
 Roadmap
 --------


### PR DESCRIPTION
The issue of run.gif not loading in README.rtf doc has been fixed.