### PR TITLE
Romansth run.gif bug fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Run the python script::
         python3 nameofthescript.py
 
 
-.. image:: ./assets/run.gif
+.. image:: ../assets/run.gif
 
 Roadmap
 --------

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Run the python script::
         python3 nameofthescript.py
 
 
-.. image:: assets/run.gif
+.. image:: ./assets/run.gif
 
 Roadmap
 --------


### PR DESCRIPTION
Hey @Aju100,
The issue of the run.gif not loading in readthedocs has been resolved. The path for run.gif has been updated to ../assets/run.gif. I've tested it on my local machine too and it's working perfectly fine.
![Screenshot from 2021-04-16 10-10-02](https://user-images.githubusercontent.com/53575561/114971408-f86dd880-9e9b-11eb-8e62-220332609866.png)
