### PR TITLE
Readme gif bug

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 ------------
 
 - wkrt7 (https://github.com/wkrt7)
+- Roman Shrestha (https://github.com/Romansth)

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,1 +1,79 @@
-.. include:: ../README.rst
+======
+asciju
+======
+
+
+.. image:: https://img.shields.io/pypi/v/asciju.svg
+        :target: https://pypi.python.org/pypi/asciju
+
+.. image:: https://img.shields.io/travis/aju100/asciju.svg
+        :target: https://travis-ci.com/aju100/asciju
+
+.. image:: https://readthedocs.org/projects/asciju/badge/?version=latest
+        :target: https://asciju.readthedocs.io/en/latest/?version=latest
+        :alt: Documentation Status
+
+
+
+
+Python package that converts image to ascii
+
+
+* Free software: MIT license
+* Documentation: https://asciju.readthedocs.io.
+* Python Package Index: https://pypi.org/project/asciju/
+
+
+Features
+--------
+
+* Conversion image to ASCII art
+
+
+Usage
+-----
+
+Convert your image into ASCII art::
+
+        from asciju import convert_img_ascii
+
+        print(convert_img_ascii('yourimage.jpeg','output.txt'))
+
+Run the python script::
+
+        python3 nameofthescript.py
+
+
+.. image:: ../assets/run.gif
+
+Roadmap
+--------
+
+* Text ASCII art
+* Video conversion on ASCII Art
+* Fix CLI argument parser
+* Improved Documentation
+* Unit Test
+
+Contribute
+------------
+.. _contribute: https://github.com/Aju100/asciju/blob/main/CONTRIBUTING.rst
+
+Contributions are always welcome! Please read the `contribution guidelines <contribute_>`_ first.
+
+Help
+----
+
+.. _pylang2: https://twitter.com/pylang2
+.. _githubissue: https://github.com/Aju100/asciju/issues/new
+
+If you need any help anywhere in the process, you can open `Github issue <githubissue_>`_ or DM a question on `Twitter <pylang2_>`_.
+
+License
+-------
+
+This project is currently licensed under the MIT General Public License v3. i.e. we guarantee end users the freedom to run, study, share, and modify the software.
+
+
+
+Made with ❤️ and Python


### PR DESCRIPTION
Hey @Aju100 , the readme gif bug has been fixed successfully. I've added a separate Readme document with proper relative link to the gif in /docs/readme.rtf and it works fine in my local machine. Also, there are no any issues regarding the gif in readme github either. 
![Screenshot from 2021-04-16 10-10-02](https://user-images.githubusercontent.com/53575561/115009735-4e5a7480-9ecc-11eb-8c9b-8b2eded1782a.png)
